### PR TITLE
Read ERB in all fixtures

### DIFF
--- a/lib/yamlint/plugin.rb
+++ b/lib/yamlint/plugin.rb
@@ -26,7 +26,7 @@ module Danger
 
         begin
           # Detect fixtures, they could contain ERB code.
-          if file.start_with?('test/fixtures/')
+          if file.include?('/fixtures/')
             YAML.load(ERB.new(File.read(file)).result)
           else
             YAML.load_file file


### PR DESCRIPTION
When using rspec, fixtures can live in in `spec/fixtures/` instead of `test/fixtures/`

This PR allows to check for other paths where fixtures could live, and apply ERB linter on them